### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install 'PyTest'
-          python -m pip install -e .
+          python -m pip install -e .[dev]
       - name: Test with pytest
         run: |
           pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        exclude:
+          - platform: macos-latest
+            python-version: "3.7"
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest setuptools
           python -m pip install -e .
       - name: Test with pytest
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,9 +12,10 @@ on:
 jobs:
   pytest:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     runs-on: ${{ matrix.platform }}
 
@@ -24,6 +25,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install pytest
+          python -m pip install -e .
       - name: Test with pytest
         run: |
           pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ setup(
             'sphinx < 2',
             # jinja2 3.0.3 was the last version to have contextfunction that sphinx 1.x needs
             'jinja2~=3.0.3',
+            'setuptools; python_version>="3.12"',
         ]
     },
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     wrapt1.13: wrapt ~= 1.13.0
     wrapt1.14: wrapt ~= 1.14.0
     coverage
+    setuptools; python_version>="3.12"
 
 [testenv:docs]
 basepython = python


### PR DESCRIPTION


<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with `pytest`
* add documentation to the relevant docstrings or pages
* add `versionadded` or `versionchanged` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->

Tests use pkg_resources, which is part of setuptools and not included by default in Python 3.12+.

```pytb
ImportError while importing test module '/private/tmp/deprecated/tests/test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test.py:2: in <module>
    import pkg_resources
E   ModuleNotFoundError: No module named 'pkg_resources'
```
