### PR TITLE
docs: fix compat with sphinx8

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,9 +173,9 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'https://docs.python.org/3/': None,
-    'https://wrapt.readthedocs.io/en/latest/': None,
-    'http://flask.pocoo.org/docs/1.0/': None,
+    'python': ('https://docs.python.org/3/', None),
+    'wrapt': ('https://wrapt.readthedocs.io/en/latest/', None),
+    'flask': ('http://flask.pocoo.org/docs/1.0/', None),
     'django': ('https://docs.djangoproject.com/en/2.1/', 'https://docs.djangoproject.com/en/2.1/_objects/'),
 }
 


### PR DESCRIPTION
Fixes errors caused by invalid intersphinx mappings.

https://docs.readthedocs.io/en/stable/guides/intersphinx.html

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with `pytest`
* add documentation to the relevant docstrings or pages
* add `versionadded` or `versionchanged` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
