### PR TITLE
v1.2.18

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.17
+current_version = 1.2.18
 commit = True
 tag = False
 message = Prepare next version {new_version} (unreleased)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
     - I decided to keep the same version number because there is really no change in the source code
       (only in comment or documentation).
 
+v1.2.18 (2024-01-25)
+====================
+
+This version does not bring any change in the source code, but fixes the build anomaly on Fedora (Packit).
+
+The package must be published on PyPi using `twine <https://pypi.org/project/twine/>`_ to correctly deal with the license file.
+
 
 v1.2.17 (2024-01-25)
 ====================

--- a/deprecated/__init__.py
+++ b/deprecated/__init__.py
@@ -7,9 +7,9 @@ Python ``@deprecated`` decorator to deprecate old python classes, functions or m
 
 """
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"
 __author__ = u"Laurent LAPORTE <laurent.laporte.pro@gmail.com>"
-__date__ = "2025-01-24"
+__date__ = "2025-01-27"
 __credits__ = "(c) Laurent LAPORTE"
 
 from deprecated.classic import deprecated

--- a/docs/source/_static/rusty-tools-background.svg
+++ b/docs/source/_static/rusty-tools-background.svg
@@ -69,4 +69,4 @@
        transform="matrix(1.087825,0,0,1.0878179,-44.130182,-11.147489)"><tspan
          x="315.95117"
          y="195.35708"
-         id="deprecated-version">v1.2.17</tspan></text></g></svg>
+         id="deprecated-version">v1.2.18</tspan></text></g></svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,7 +61,7 @@ author = 'Marcos CARDOSO & Laurent LAPORTE'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = "1.2.17"
+release = "1.2.18"
 # The short X.Y version.
 version = release.rpartition('.')[0]
 

--- a/python-deprecated.spec
+++ b/python-deprecated.spec
@@ -2,7 +2,7 @@
 %global pkgname deprecated
 
 Name:           python-%{pkgname}
-Version:        1.2.17
+Version:        1.2.18
 Release:        1%{?dist}
 Summary:        Python decorator to deprecate old python classes, functions or methods
 License:        MIT

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ from setuptools import setup
 
 setup(
     name="Deprecated",
-    version="1.2.17",
+    version="1.2.18",
     url="https://github.com/laurent-laporte-pro/deprecated",
     project_urls={
         "Documentation": "https://deprecated.readthedocs.io/en/latest/",


### PR DESCRIPTION
When preparing the wheel for the `Deprecated` package, the license file should not be included in the metadata (`METADATA`) of the wheel if using version 2.1 or 2.2 of the format. Instead, the `LICENSE.rst` file should simply be added.

To build the wheel, you can use the tool `pyproject-build` (see the [[documentation here](https://pythonspeed.com/articles/pyproject-build/)](https://pythonspeed.com/articles/pyproject-build/)).

To publish the wheel on PyPI, you must use `twine` (see the [[documentation here](https://twine.readthedocs.io/en/stable/)](https://twine.readthedocs.io/en/stable/)), as we are experiencing an issue with `uv publish`.

```bash
pyproject-build
twine upload -r testpypi dist/*  # to publish on Test PyPi
```

close #83 